### PR TITLE
Altered API URL to include proxy path

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,4 +1,4 @@
-const API_HOST = window.location.origin + "/api";
+const API_HOST = window.location.href + "api";
 
 // CACHE OF DATABASES
 let DATABASES = undefined;


### PR DESCRIPTION
Not sure if this is appropriate or if I've messed something else, but this fixed my issue with DB access in the case where you use an NGINX proxy_pass instead of directly connecting to it via the specified port. Base version works with e.g. localhost:3000 ->
localhost:3000/api/databases, but with redirect at eg localhost/synonymsearch/, looks at localhost/api/databases instead of localhost/synonymsearch/api/databases. Again, this change works for me in both the localhost:3000 and localhost/synonymsearch configurations, but have not tested it in other configurations.