### PR TITLE
API URL Definition: remove possible query string, add trailing slash

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,4 +1,4 @@
-const API_HOST = window.location.href + "api";
+const API_HOST = window.location.href.split(/[?#]/)[0].replace(/\/?$/, '/') + "api";
 
 // CACHE OF DATABASES
 let DATABASES = undefined;


### PR DESCRIPTION
A small fix in addition to #1 